### PR TITLE
[FIX] Signup screen navbar toggle for mid size devices

### DIFF
--- a/designs/UI/dashboard.html
+++ b/designs/UI/dashboard.html
@@ -30,7 +30,7 @@
                             <a class="nav-link" href="#">New Category</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="login.html">Logout<span class="sr-only">(current)</span></a>
+                            <a class="nav-link" href="login.html">Logout</a>
                         </li>
                     </ul>
                 </div>

--- a/designs/UI/signup.html
+++ b/designs/UI/signup.html
@@ -15,27 +15,27 @@
     </head>
     <body>
         <header class="navbar navbar-toggleable-md navbar-light bg-primary bg-faded">
-            <nav class="container w-100">
-                <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-                <a class="navbar-brand" href="./index.html">Yummy Recipes</a>
-                
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav mr-auto">
-                        <li class="nav-item">
-                            <a class="nav-link" href="./index.html">Home</a>
-                        </li>
-                        <li class="nav-item active">
-                            <a class="nav-link" href="#">Sign Up <span class="sr-only">(current)</span></a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="./login.html">Login</a>
-                        </li>
-                    </ul>
-                </div>
-            </nav>
-        </header>
+                <nav class="container w-100">
+                    <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <a class="navbar-brand" href="index.html">Yummy Recipes</a>
+                    
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav mr-auto">
+                            <li class="nav-item active">
+                                <a class="nav-link" href="index.html">Home</a>
+                            </li>
+                            <li class="nav-item active">
+                                <a class="nav-link" href="#">Sign Up<span class="sr-only">(current)</span></a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" href="login.html">Login</a>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+            </header>
         <form class="container " action="./dashboard.html">
             <div class="form-group">
                 <label for="enterEmail">Email Address</label>

--- a/designs/UI/signup.html
+++ b/designs/UI/signup.html
@@ -67,6 +67,6 @@
         <!-- jQuery first then Tether and finally Bootstrap -->
         <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" crossorigin="anonymous"></script>
-        <script src="./bootstrap-4.0.0-alpha.6/js/bootstrap.min.js"></script>
+        <script src="js/bootstrap.min.js"></script>
     </body>
 </html>


### PR DESCRIPTION
### What this PR does
The current implementation of the UI [here](https://indungu.github.io/yummy-recipes) did not toggle the `navbar` when clicked/tapped when on the `signup` page.
### Where to start
Open the current hosted static UI preferably on a mobile device so as to have access to the `nav-toggler` by entering this url in your browser: https://indungu.github.io/yummy-recipes
Navigate to the `signup` page by clicking the `Sign Up` link or button.
### How/What to test
Clone the `dev` branch and test locally through:
```
    1.  git clone -b dev https://github.com/indungu/yummy-recipes
    2. cd yummy-recipes
    3. open index.html in Chrome browser preferably
    4. navigate to signup.html
    5. Open developer tools [Ctrl+Shift+I] 
    6. Simulate test against mobile device through toggle device [Ctrl+Shift+M]
    7. Click the navbar toggle icon and check if it display-then-hides the navbar
```
### Questions
How else can then navbar toggling be achieved? (if any alternatives exist that is)
On a scale of 1-10, where one is *extremely unfriendly* and  ten *super friendly*, how would you gauge the usability of the current UI design?
