### PR TITLE
Fixed Coveralls null report

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,2 @@
-repo_token: eHxd7JnwlGDSfka50xT36dSd008lHopTs
+repo_token: 74i7NEFfdkl0yGooaD7iNInosSMExb3Pt
 service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   - pip install -r requirements.txt
 # Test script
 script:
-  - pytest --cov=app tests/
+  - pytest --cov-report term-missing --cov=app tests/
 after_success:
   - coveralls
 # Notification config

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 script:
   - pytest --cov-report term-missing --cov=app tests/
 after_success:
-  - coveralls
+  - coveralls --ignore-errors
 # Notification config
 notifications:
   email:


### PR DESCRIPTION
```bat
coverage.misc.NotPython: Couldn't parse 'C:\Users\FAM\BOOTCAMP-XXIII\Challenges\Challenge_2\yummy-recipes\app\templates\_formhelpers.html' as Python
source: 'invalid syntax' at line 1
```

The above is the last line of a traceback error raised by `coveralls` when using the `_formhelper.html` macro.

The `After success:` key value on the `.travis.yml` config file was changed to `coveralls --ignore-errors`.